### PR TITLE
Added board grid field, and  generation

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -4,9 +4,14 @@ class Board < ApplicationRecord
   DEFAULT_HEIGHT = 10.freeze
   DEFAULT_DENSITY = 5.freeze  # 1/5
 
+  MAX_WIDTH = 1000.freeze
+  MAX_HEIGHT = 1000.freeze
+
   attribute :width, :integer, default: DEFAULT_WIDTH
   attribute :height, :integer, default: DEFAULT_HEIGHT
   attribute :mines, :integer, default: ((DEFAULT_WIDTH * DEFAULT_HEIGHT) / DEFAULT_DENSITY).to_int
+
+  before_create :create_grid
 
   scope :recent, -> (num) { order(:created_at).reverse.first(num) }
 
@@ -14,11 +19,101 @@ class Board < ApplicationRecord
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }   # There's a gem for this...
   validates_with BoardValidator   # validators/board_validator
  
-  def render_grid()
-   render = \
-     "💣◻◻💣◻💣◻◻💣◻" + "\n" +
-     "💣◻💣◻💣◻💣◻◻◻" + "\n" +
-     "💣◻◻💣◻◻💣💣◻◻" + "\n" +
-     "💣◻💣◻◻💣◻◻💣◻" + "\n"
+  def tiles
+    @tiles || @tiles = self.width * self.height
   end
+
+
+  #
+  # Generate the board grid
+  #
+
+  # Create empty grid
+  # If the density of mines is > 50%, we initialise the board to be full of mines
+  # and then clear the required number of tiles. This reduces how many tiles we
+  # have to place, and also the collision rate for naive placement.
+  def create_grid
+    board_color = self.mines > (tiles / 2) ? true : false
+
+    # Postgres array fields can be multidimensional, but since we're just
+    # placing mines randdomly, it's easier to deal with 1d, and only worry about
+    # coverting to 2d in the render
+    # self.grid = Array.new(self.height){Array.new(self.width, board_color)}
+    grid = Array.new(tiles, board_color)  
+                                
+    n = board_color ? (tiles - self.mines) : self.mines
+
+    self.grid = set_tiles_lfsr(grid, n, !board_color)
+  end
+
+
+  # Simply place mines or blanks at random, trying again if we get a collision.
+  # We should get at most 50% collision rate
+  def set_tiles_naive(grid, num, color)
+    while num > 0
+      tile = Random.rand(tiles)
+      if not grid[tile] == color
+        grid[tile] = color
+        num -= 1
+      end
+    end
+    grid
+  end
+
+
+  # A maximal lfsr has the magical property of visiting each element of a ^2 range
+  # in psuedo-random order. Since there are no collisions we don't need to check
+  # if a mine has already been placed in that position.
+  def set_tiles_lfsr(grid, num, color)
+    # Not-at-all-optimal selection of maximal lfsr taps for 2^n where n 4..32
+    lfsr_taps = [
+      0,1,3,6,0x9,0x12,0x21,0x41,0x8E,0x108,0x204,0x402,0x829,0x100D,0x2015,0x4001,
+      0x8016,0x10004,0x20013,0x40013,0x80004,0x100002,0x200001,0x400010,0x80000D,
+      0x1000004,0x2000023,0x4000013,0x8000004,0x10000002,0x20000029,0x40000004,0x80000057 ]
+
+    # Find the nearest power of 2 that covers how many tiles there are.
+    # we need 1 more, because lfsr does not generate 0, so we need to -1 each random
+
+    log2 = Math.log2(tiles+1).ceil    # could find this by bit-shifting, for speed
+    taps = lfsr_taps[log2]
+    lfsr = Random.rand(1..tiles)      # seed the lfsr. could be 1..2**log2-1
+
+    while num > 0
+      if (lfsr <= tiles)
+        grid[lfsr-1] = color
+        num -= 1
+      end
+
+      lfsr = ((lfsr & 1) == 0) \
+        ? (lfsr >> 1)
+        : (lfsr >> 1) ^ taps
+    end
+    grid
+  end
+
+
+  def set_tiles_randomized_heap_or_queue_or_linked_list(num, color)
+    # I mean we could, but seriously...
+  end
+
+
+  # this can be sped up a lot, perhaps just store chars directly in the db
+  # or just serve the raw array to be rendered on the client, etc
+  # should prob. go in view model or whatever
+  def render_grid()
+    grid = self.grid
+    render = ""
+    t = 0
+
+    self.height.times do
+      self.width.times do
+        c = grid[t] ? '💣' : '◻'
+        render << c
+        t += 1
+      end
+      render << "\n"
+    end
+    render
+  end
+
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -4,9 +4,6 @@ class Board < ApplicationRecord
   DEFAULT_HEIGHT = 10.freeze
   DEFAULT_DENSITY = 5.freeze  # 1/5
 
-  MAX_WIDTH = 1000.freeze
-  MAX_HEIGHT = 1000.freeze
-
   attribute :width, :integer, default: DEFAULT_WIDTH
   attribute :height, :integer, default: DEFAULT_HEIGHT
   attribute :mines, :integer, default: ((DEFAULT_WIDTH * DEFAULT_HEIGHT) / DEFAULT_DENSITY).to_int

--- a/db/migrate/20230519121629_add_grid_to_board.rb
+++ b/db/migrate/20230519121629_add_grid_to_board.rb
@@ -1,0 +1,10 @@
+class AddGridToBoard < ActiveRecord::Migration[7.0]
+  def change
+    change_table :boards do |t|
+      # postgres stores boolean as a byte to accommodate NULL
+      # A bit wasteful for our purpose, but simpler than
+      # bit-twiddling a binary type as a bitmask
+      t.boolean :grid, array: true, default: []
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_19_030734) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_19_121629) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_030734) do
     t.integer "mines"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "grid", default: [], array: true
   end
 
 end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Board, type: :model do
   let(:board) { create(:board) }
 
   context "Validations" do
-    [:name, :email, :width, :height, :mines].each do |attr|
+    [:name, :email].each do |attr|
       it { should validate_presence_of(attr) }
     end
   end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -4,8 +4,17 @@ RSpec.describe Board, type: :model do
   let(:board) { create(:board) }
 
   context "Validations" do
-    [:name, :email].each do |attr|
+    [:name, :email, :width, :height, :mines].each do |attr|
       it { should validate_presence_of(attr) }
     end
   end
+
+  context "Grid", focus: true do
+    it "creates a grid" do
+      #g = create_grid
+      #b place_mines( g, mines)
+      #b.compact.count = mines
+    end
+  end
 end
+


### PR DESCRIPTION
Here we Add a grid field to the Board model, which is simply a 1D array of booleans.

Postgres does support multi-dimensional arrays, but it's easier to place mines in 1D given we don't have any 2D constraints on mine placement. We only need to worry about 2D when rendering the grid.

For grid generation, we first create the grid. If the mine density is .50%, we initialize the grid to mines, and then 'place' blank tiles. This way we always have a board that is at most 50% 'full', and our collision rate will be at most 50%.

There is a 'naive' mine placement method that simplty places mines (or blanks) at random, and retries if the tile is already 'colored'.

Additionally there is a more advanced LFSR placement method. This uses a maximal LFSR of the correct size for the board to allocate mines (or blanks) without collisions (due to the magical nature of maximal LFSRs).
