### PR TITLE
Added board model specs to test grid_create

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.2)
     minitest (5.18.0)
     msgpack (1.7.0)
     net-imap (0.3.4)
@@ -145,6 +146,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.0)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.0-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -252,6 +256,8 @@ GEM
       sprockets (>= 3.0.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    tailwindcss-rails (2.0.29)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.29-x86_64-darwin)
       railties (>= 6.0.0)
     thor (1.2.2)
@@ -281,6 +287,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  ruby
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -1,19 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe Board, type: :model do
-  let(:board) { create(:board) }
+  let(:subject) { build(:board) }
 
   context "Validations" do
     [:name, :email].each do |attr|
       it { should validate_presence_of(attr) }
+      it "should validate the email format"
     end
   end
 
-  context "Grid", focus: true do
+  context "Grid" do
     it "creates a grid" do
-      #g = create_grid
-      #b place_mines( g, mines)
-      #b.compact.count = mines
+      g = subject.create_grid
+      expect(g.count).to eq(subject.width * subject.height)
+    end
+
+    it "creates a single mine" do
+      subject.mines = 1
+      g = subject.create_grid
+      expect(g.count(true)).to eq(1)
+    end
+
+    it "creates full board of mines" do
+      tiles = subject.width * subject.height
+      subject.mines = tiles - 1
+      g = subject.create_grid
+      expect(g.count(true)).to eq(tiles-1)
+    end
+
+    it "creates mines max collision" do
+      tiles = subject.width * subject.height
+      subject.mines = tiles / 2
+      g = subject.create_grid
+      expect(g.count(true)).to eq(tiles/2)
+    end
+
+    it "creates a big grid" do
+      subject = Board.new(width: 1_000, height: 1_000, mines: 500_000)
+      g = subject.create_grid
+      expect(g.count(true)).to eq(500_000)
+      expect(g.count).to eq(1_000_000)
     end
   end
 end


### PR DESCRIPTION
Add board model specs for create_grid(), checking that the created board is the correct size, and has the correct number of mines.