### PR TITLE
Notes on LFSR, and use naive allocator by default

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -41,12 +41,14 @@ class Board < ApplicationRecord
                                 
     n = board_color ? (tiles - self.mines) : self.mines
 
-    self.grid = set_tiles_lfsr(grid, n, !board_color)
+    self.grid = set_tiles_naive(grid, n, !board_color)
+    #self.grid = set_tiles_lfsr(grid, n, !board_color)
   end
 
 
   # Simply place mines or blanks at random, trying again if we get a collision.
-  # We should get at most 50% collision rate
+  # We should get at most 50% collision rate. If for some reason we wanted a
+  # lower collision rate, we could create and oversized hash of mine positions.
   def set_tiles_naive(grid, num, color)
     while num > 0
       tile = Random.rand(tiles)
@@ -62,6 +64,12 @@ class Board < ApplicationRecord
   # A maximal lfsr has the magical property of visiting each element of a ^2 range
   # in psuedo-random order. Since there are no collisions we don't need to check
   # if a mine has already been placed in that position.
+  # 
+  # The disadvantage is that it's not really random - At each size of lfsr
+  # we're just taking a different 'window' of that sequence depending on board size
+  # and number of mines.
+  # It's fairly convincing in general, but the naive allocator is probably a better
+  # choice if this were used seriously.
   def set_tiles_lfsr(grid, num, color)
     # Not-at-all-optimal selection of maximal lfsr taps for 2^n where n 4..32
     lfsr_taps = [
@@ -91,7 +99,7 @@ class Board < ApplicationRecord
 
 
   def set_tiles_randomized_heap_or_queue_or_linked_list(num, color)
-    # I mean we could, but seriously...
+    # I mean, we could ...
   end
 
 

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe Board, type: :model do
       expect(g.count(true)).to eq(500_000)
       expect(g.count).to eq(1_000_000)
     end
+
+    it "creates a tiny grid" do
+      subject = Board.new(width: 2, height: 2, mines: 2)
+      g = subject.create_grid
+      expect(g.count(true)).to eq(2)
+      expect(g.count).to eq(4)
+    end
   end
 end
 


### PR DESCRIPTION
Had fun with LFSR but of course it's not actually random.

It makes convincing boards, but many boards of the same size will show some repeat structures.

Switching to the default random allocator. This still gets a low collision rate (max 50%) even with very full boards because we allocated blanks instead of mines if the board is going to be >50% full.

If we needed better, we could build an oversized hash of mine positions. Ruby sets might work for this, but they are just a Hash without values