### PR TITLE
Choose naive allocator, remove lfsr experiment

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -42,14 +42,12 @@ class Board < ApplicationRecord
     n = board_color ? (tiles - self.mines) : self.mines
 
     self.grid = set_tiles_naive(grid, n, !board_color)
-    #self.grid = set_tiles_lfsr(grid, n, !board_color)
     #self.grid = set_tiles_set(grid, n, !board_color)
   end
 
 
   # Simply place mines or blanks at random, trying again if we get a collision.
-  # We should get at most 50% collision rate. If for some reason we wanted a
-  # lower collision rate, we could create and oversized hash of mine positions.
+  # We should get at most 50% collision rate.
   def set_tiles_naive(grid, num, color)
     while num > 0
       tile = Random.rand(tiles)
@@ -62,45 +60,9 @@ class Board < ApplicationRecord
   end
 
 
-  # A maximal lfsr has the magical property of visiting each element of a ^2 range
-  # in psuedo-random order. Since there are no collisions we don't need to check
-  # if a mine has already been placed in that position.
-  # 
-  # The disadvantage is that it's not really random - At each size of lfsr
-  # we're just taking a different 'window' of that sequence depending on board size
-  # and number of mines.
-  # It's fairly convincing in general, but the naive allocator is probably a better
-  # choice if this were used seriously.
-  def set_tiles_lfsr(grid, num, color)
-    # Not-at-all-optimal selection of maximal lfsr taps for 2^n where n 4..32
-    lfsr_taps = [
-      0,1,3,6,0x9,0x12,0x21,0x41,0x8E,0x108,0x204,0x402,0x829,0x100D,0x2015,0x4001,
-      0x8016,0x10004,0x20013,0x40013,0x80004,0x100002,0x200001,0x400010,0x80000D,
-      0x1000004,0x2000023,0x4000013,0x8000004,0x10000002,0x20000029,0x40000004,0x80000057 ]
-
-    # Find the nearest power of 2 that covers how many tiles there are.
-    # we need 1 more, because lfsr does not generate 0, so we need to -1 each random
-
-    log2 = Math.log2(tiles+1).ceil    # could find this by bit-shifting, for speed
-    taps = lfsr_taps[log2]
-    lfsr = Random.rand(1..tiles)      # seed the lfsr. could be 1..2**log2-1
-
-    while num > 0
-      if (lfsr <= tiles)
-        grid[lfsr-1] = color
-        num -= 1
-      end
-
-      lfsr = ((lfsr & 1) == 0) \
-        ? (lfsr >> 1)
-        : (lfsr >> 1) ^ taps
-    end
-    grid
-  end
-
-
   # Use a set to keep track of allocated mines.
-  # Probablly the more correct implementation, but slower.
+  # More correct in some ways, but actually slower than naive allocation, since
+  # inserting items in the set is subject to collision as the hash gets fuller.
   def set_tiles_set(grid, num, color)
     set = Set.new
     while num > 0

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -41,22 +41,7 @@ class Board < ApplicationRecord
                                 
     n = board_color ? (tiles - self.mines) : self.mines
 
-    self.grid = set_tiles_naive(grid, n, !board_color)
-    #self.grid = set_tiles_set(grid, n, !board_color)
-  end
-
-
-  # Simply place mines or blanks at random, trying again if we get a collision.
-  # We should get at most 50% collision rate.
-  def set_tiles_naive(grid, num, color)
-    while num > 0
-      tile = Random.rand(tiles)
-      if not grid[tile] == color
-        grid[tile] = color
-        num -= 1
-      end
-    end
-    grid
+    self.grid = set_tiles_set(grid, n, !board_color)
   end
 
 


### PR DESCRIPTION
Remove the lfsr allocator as it's not truly random, though convincing.
Remove the naive allocator, even though it's the fastest. It relies on low collision rate because we only allocate either mines or tiles, whichever are fewer.
The set allocator is more general.
 