### PR TITLE
select only the fields we need for index views, particularly don't se…

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -10,8 +10,10 @@ class Board < ApplicationRecord
 
   before_create :create_grid
 
-  scope :recent, -> (num) { order(:created_at).reverse.first(num) }
-  scope :all_recent_first, -> { order(:created_at).reverse }
+
+  scope :index_fields, -> { select(:id, :name, :email, :width, :height, :mines, :created_at) }
+  scope :all_recent_first, -> { index_fields.order(:created_at).reverse }
+  scope :recent, -> (num) { index_fields.order(:created_at).reverse.first(num) }
 
   validates :name, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }   # There's a gem for this...


### PR DESCRIPTION
A consequence of including the grid array directly in the board model is that ActiveRecord does a 'select * from' by default, and retrieves the grid for each record, even if it's not required. For example in index views.
Here we scope only the fields we need for index views.