### PR TITLE
Add date index, fix rails scopes

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -15,8 +15,8 @@ class Board < ApplicationRecord
   # grid data could go in it's owm model instead of this, at the cost of a join
   scope :index_fields, -> { select(:id, :name, :email, :width, :height, :mines, :created_at) }
 
-  scope :all_recent_first, -> { index_fields.order(:created_at).reverse }
-  scope :recent, -> (num) { all_recent_first.first(num) }
+  scope :all_recent_first, -> { index_fields.order('created_at DESC') }
+  scope :recent, -> (num) { all_recent_first.limit(num) }
 
   validates :name, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }   # There's a gem for this...

--- a/db/migrate/20230522033849_add_index_to_boards.rb
+++ b/db/migrate/20230522033849_add_index_to_boards.rb
@@ -1,0 +1,5 @@
+class AddIndexToBoards < ActiveRecord::Migration[7.0]
+  def change
+    add_index :boards, :created_at, order: {created_at: :desc}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_19_121629) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_22_033849) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_19_121629) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "grid", default: [], array: true
+    t.index ["created_at"], name: "index_boards_on_created_at", order: :desc
   end
 
 end


### PR DESCRIPTION
Add created_at index to boards (there's some debate on if this is faster, but posgres 'explain analyze' says it is), and fixed the scopes to use SQL queries rather than ruby array methods.

I'd forgotten all about this kind of fun with ActiveRecord, Arel, etc.

Now the SQL makes sense 'select ... from boards order by created_at DESC limit 10', instead of 'select ... order by ASC' and then rails processes the array.